### PR TITLE
Add Apple Watch Mode

### DIFF
--- a/Application/AppDelegate.m
+++ b/Application/AppDelegate.m
@@ -66,7 +66,7 @@ XPCDaemonClient* xpcDaemonClient;
         
         NSArray* args = NSProcessInfo.processInfo.arguments;
         NSMutableDictionary* initialPreferences = [NSMutableDictionary dictionary];
-        NSArray* prefKeys = @[PREF_PASSIVE_MODE, PREF_TOUCH_ID_MODE];
+        NSArray* prefKeys = @[PREF_PASSIVE_MODE, PREF_TOUCH_ID_MODE, PREF_APPLE_WATCH_MODE];
             
         //extract set key/value pairs
         for(NSString* key in prefKeys) {

--- a/Application/Preferences.xib
+++ b/Application/Preferences.xib
@@ -30,7 +30,7 @@
         <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <rect key="contentRect" x="196" y="240" width="600" height="432"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1410"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="949"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="600" height="432"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -84,11 +84,11 @@
             <point key="canvasLocation" x="-1654" y="211"/>
         </window>
         <customView id="K6i-xr-27e" userLabel="Modes">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="220"/>
+            <rect key="frame" x="0.0" y="0.0" width="600" height="230"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button tag="1" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Bog-hz-gcd">
-                    <rect key="frame" x="20" y="183" width="18" height="18"/>
+                    <rect key="frame" x="20" y="193" width="18" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="Aaw-XT-TEt">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -99,7 +99,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kjh-jc-STu">
-                    <rect key="frame" x="44" y="185" width="160" height="15"/>
+                    <rect key="frame" x="44" y="195" width="160" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="No Icon Mode" id="4EN-j2-enV">
                         <font key="font" size="13" name="Menlo-Bold"/>
@@ -108,7 +108,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="471" translatesAutoresizingMaskIntoConstraints="NO" id="xaO-g8-rdS">
-                    <rect key="frame" x="44" y="167" width="475" height="15"/>
+                    <rect key="frame" x="44" y="177" width="475" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Run without showing an icon in the status menu bar." id="SG5-YM-BoV">
                         <font key="font" size="13" name="Menlo-Regular"/>
@@ -117,7 +117,7 @@
                     </textFieldCell>
                 </textField>
                 <button tag="2" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fCw-dO-UjA">
-                    <rect key="frame" x="20" y="127" width="18" height="18"/>
+                    <rect key="frame" x="20" y="137" width="18" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="cSM-qy-UBH">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -128,7 +128,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6O1-eb-lIz">
-                    <rect key="frame" x="44" y="129" width="266" height="15"/>
+                    <rect key="frame" x="44" y="139" width="266" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Passive Mode" id="lOS-sK-Fxz">
                         <font key="font" size="13" name="Menlo-Bold"/>
@@ -137,7 +137,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="471" translatesAutoresizingMaskIntoConstraints="NO" id="uaA-gL-8Kf">
-                    <rect key="frame" x="44" y="111" width="475" height="15"/>
+                    <rect key="frame" x="44" y="121" width="475" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Run without showing local alerts." id="poq-d5-agm">
                         <font key="font" size="13" name="Menlo-Regular"/>
@@ -145,8 +145,37 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <button tag="2" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X81-1y-8Dw">
+                    <rect key="frame" x="20" y="84" width="18" height="18"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="ZJ6-1v-z1Y">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="menu" size="14"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="togglePreference:" target="-2" id="rqf-6r-0z5"/>
+                    </connections>
+                </button>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="L9f-BX-v8p">
+                    <rect key="frame" x="44" y="87" width="266" height="15"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Apple Watch Mode" id="Tbf-yG-ppD">
+                        <font key="font" size="13" name="Menlo-Bold"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="471" id="Sg4-5J-u5e">
+                    <rect key="frame" x="44" y="64" width="475" height="15"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Ignore events if followed by Apple Watch authentication." id="vrK-mY-QZR">
+                        <font key="font" size="13" name="Menlo-Regular"/>
+                        <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <button tag="3" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SGy-OV-jnw">
-                    <rect key="frame" x="20" y="71" width="18" height="18"/>
+                    <rect key="frame" x="20" y="30" width="18" height="18"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="KBB-UE-Vou">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -157,7 +186,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DA8-0T-xml">
-                    <rect key="frame" x="44" y="73" width="266" height="15"/>
+                    <rect key="frame" x="44" y="32" width="266" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Touch ID Mode" id="6NT-Rz-J4V">
                         <font key="font" size="13" name="Menlo-Bold"/>
@@ -166,7 +195,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="471" translatesAutoresizingMaskIntoConstraints="NO" id="7Vs-Bo-OXu">
-                    <rect key="frame" x="44" y="56" width="475" height="15"/>
+                    <rect key="frame" x="44" y="10" width="475" height="15"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Ignore events if followed by biometric authentication." id="LYZ-UX-Ve7">
                         <font key="font" size="13" name="Menlo-Regular"/>
@@ -175,7 +204,7 @@
                     </textFieldCell>
                 </textField>
             </subviews>
-            <point key="canvasLocation" x="-986" y="26"/>
+            <point key="canvasLocation" x="-986" y="31"/>
         </customView>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
@@ -496,6 +525,15 @@ Install Telegram, create a free bot and paste your token below. Then scan the QR
             </subviews>
             <point key="canvasLocation" x="1011" y="46"/>
         </customView>
+        <button verticalHuggingPriority="750" id="bDj-wb-DQr">
+            <rect key="frame" x="0.0" y="0.0" width="61" height="18"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <buttonCell key="cell" type="check" title="Check" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="o5g-hn-BeZ">
+                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                <font key="font" metaFont="system"/>
+            </buttonCell>
+            <point key="canvasLocation" x="-1311" y="-148"/>
+        </button>
     </objects>
     <resources>
         <image name="PrefsAlerts" width="64" height="64"/>

--- a/Application/PrefsWindowController.m
+++ b/Application/PrefsWindowController.m
@@ -50,6 +50,7 @@ extern XPCDaemonClient* xpcDaemonClient;
 #define BUTTON_NO_REMOTE_ALERTS_MODE 5
 #define BUTTON_EXECUTE_ACTION 6
 #define BUTTON_NO_UPDATE_MODE 7
+#define BUTTON_APPLE_WATCH_MODE 8
 
 //init 'general' view
 // add it, and make it selected
@@ -119,6 +120,7 @@ extern XPCDaemonClient* xpcDaemonClient;
             view = self.modesView;
             
             ((NSButton*)[view viewWithTag:BUTTON_NO_ICON_MODE]).state = [self.preferences[PREF_NO_ICON_MODE] boolValue];
+            ((NSButton*)[view viewWithTag:BUTTON_APPLE_WATCH_MODE]).state = [self.preferences[PREF_APPLE_WATCH_MODE] boolValue];
             ((NSButton*)[view viewWithTag:BUTTON_TOUCH_ID_MODE]).state = [self.preferences[PREF_TOUCH_ID_MODE] boolValue];
             
             break;
@@ -239,6 +241,11 @@ extern XPCDaemonClient* xpcDaemonClient;
         //touch id mode
         case BUTTON_TOUCH_ID_MODE:
             updatedPreferences[PREF_TOUCH_ID_MODE] = state;
+            break;
+        
+        //apple watch mode
+        case BUTTON_APPLE_WATCH_MODE:
+            updatedPreferences[PREF_APPLE_WATCH_MODE] = state;
             break;
             
         //include image mode

--- a/Daemon/Monitor.h
+++ b/Daemon/Monitor.h
@@ -47,6 +47,8 @@
 
 //last touch ID auth timestamp (set by persistent ES client)
 @property(atomic, retain)NSDate* lastTouchIDAuth;
+// last Apple Watch auth timetstamp (set by persistent ES client)
+@property(atomic, retain)NSDate* lastAppleWatchAuth;
 
 /* METHODS */
 
@@ -54,6 +56,6 @@
 -(BOOL)start;
 -(BOOL)isExternalDisplayActive;
 -(void)processEvent:(NSString*)timestamp;
--(BOOL)waitForTouchID:(NSTimeInterval)timeout;
+-(BOOL)waitForSecureAuth:(NSTimeInterval)timeout :(BOOL)touchIdAllowed :(BOOL)appleWatchAllowed :(NSString*) authMethodUsed;
 
 @end

--- a/Daemon/Monitor.m
+++ b/Daemon/Monitor.m
@@ -107,17 +107,21 @@ static void pmDomainChange(void *refcon, io_service_t service, uint32_t messageT
         // log to file
         os_log_info(logHandle, "[NEW EVENT] lid state: open (sleep state: %d)", sleepState);
         
-        //touch id mode?
+        BOOL touchIdAllowed = YES == [preferences.preferences[PREF_TOUCH_ID_MODE] boolValue];
+        BOOL appleWatchAllowed = YES == [preferences.preferences[PREF_APPLE_WATCH_MODE] boolValue];
+        
+        //is a mode of secure authentication set to skip an alert?
         // wait up to 7 seconds, and ignore event if user auth'd via biometrics
-        if(YES == [preferences.preferences[PREF_TOUCH_ID_MODE] boolValue])
+        if(touchIdAllowed || appleWatchAllowed)
         {
             //dbg msg
-            os_log_debug(logHandle, "'touch ID' mode enabled, waiting for biometric auth event");
+            os_log_debug(logHandle, "'secure auth' mode enabled, waiting for event");
             
-            //wait for touch ID
-            if(YES == [monitor waitForTouchID:7.0])
+            //wait for a trustworthy authentication event
+            NSString* authMethodUsed = NULL;
+            if(YES == [monitor waitForSecureAuth:touchIdAllowed:appleWatchAllowed:7.0:authMethodUsed])
             {
-                os_log_info(logHandle, "user authenticated via touch ID, ignoring event");
+                os_log_info(logHandle, "user authenticated via %@, ignoring event", authMethodUsed);
                 goto bail;
             }
         }
@@ -250,8 +254,8 @@ bail:
         goto bail;
     }
     
-    //start touch ID monitoring
-    [self startTouchIDMonitor];
+    //start authentication monitoring
+    [self startAuthMonitor];
     
     //happy
     registered = YES;
@@ -285,8 +289,8 @@ bail:
     //mark stopped
     running = NO;
     
-    //stop touch id monitoring
-    [self stopTouchIDMonitor];
+    //stop authentication monitoring
+    [self stopAuthMonitor];
     
     //have a dispatch queue?
     // serialize teardown with in-flight callbacks
@@ -358,8 +362,8 @@ bail:
     return NO;
 }
 
-//start persistent ES client for touch ID auth monitoring
--(void)startTouchIDMonitor
+//start persistent ES client for authentication event monitoring
+-(void)startAuthMonitor
 {
     //already running?
     if(esAuthClient) return;
@@ -370,18 +374,29 @@ bail:
         //only care about auth events
         if(msg->event_type != ES_EVENT_TYPE_NOTIFY_AUTHENTICATION) return;
         
-        //only care about Touch ID successes
-        if(msg->event.authentication->type    != ES_AUTHENTICATION_TYPE_TOUCHID) return;
+        //only care about auth events that unlocked the account
         if(msg->event.authentication->success != YES) return;
         
-        //record timestamp
-        self.lastTouchIDAuth = [NSDate date];
-        
-        os_log_debug(logHandle, "touch ID auth detected");
+        // only care about Touch ID or Apple Watch successes
+        switch(msg->event.authentication->type) {
+            //record timestamp
+            case ES_AUTHENTICATION_TYPE_TOUCHID:
+                self.lastTouchIDAuth = [NSDate date];
+                os_log_debug(logHandle, "touch ID auth detected");
+                break;
+            case ES_AUTHENTICATION_TYPE_AUTO_UNLOCK:
+                //only care about when the Apple Watch unlocked the machine itself
+                if(msg->event.authentication->data.auto_unlock->type != ES_AUTO_UNLOCK_MACHINE_UNLOCK) return;
+                self.lastAppleWatchAuth = [NSDate date];
+                os_log_debug(logHandle, "apple watch auth detected");
+                break;
+            default:
+                return;
+        }
     });
     
     if(ES_NEW_CLIENT_RESULT_SUCCESS != result) {
-        os_log_error(logHandle, "ERROR: failed to create ES client for touch ID monitoring (result: %d)", result);
+        os_log_error(logHandle, "ERROR: failed to create ES client for authentication monitoring (result: %d)", result);
         esAuthClient = NULL;
         return;
     }
@@ -395,43 +410,56 @@ bail:
         return;
     }
     
-    os_log_debug(logHandle, "persistent touch ID monitor started");
+    os_log_debug(logHandle, "persistent authentication monitor started");
 }
 
 //stop persistent ES client
--(void)stopTouchIDMonitor
+-(void)stopAuthMonitor
 {
     if(esAuthClient) {
         es_unsubscribe_all(esAuthClient);
         es_delete_client(esAuthClient);
         esAuthClient = NULL;
-        os_log_debug(logHandle, "persistent touch ID monitor stopped");
+        os_log_debug(logHandle, "persistent authentication monitor stopped");
     }
 }
 
-//wait for a touch ID auth event
+//wait for a trustworhy auth event, Apple Watch or touch ID
 // polls the persistent ES client's timestamp
--(BOOL)waitForTouchID:(NSTimeInterval)timeout
+-(BOOL)waitForSecureAuth:(NSTimeInterval)timeout :(BOOL)touchIdAllowed :(BOOL)appleWatchAllowed :(NSString*) authMethodUsed
 {
     //no ES client?
     if(!esAuthClient) {
-        os_log_error(logHandle, "waitForTouchID: no ES client (FDA not granted?)");
+        os_log_error(logHandle, "waitForSecureAuth: no ES client (FDA not granted?)");
         return NO;
     }
     
     //reference time (lid just opened)
     NSDate* lidOpenTime = [NSDate date];
     
-    //poll for touch ID auth
+    //poll for auth
     NSTimeInterval elapsed = 0;
     while(elapsed < timeout)
     {
-        //check if a touch ID auth occurred after lid open
-        NSDate* authTime = self.lastTouchIDAuth;
+        NSDate* authTime = NULL;
+        NSString* authTypeFound = NULL;
+        if(touchIdAllowed) {
+            //check if a touch ID auth occurred after lid open
+            authTime = self.lastTouchIDAuth;
+            authTypeFound = @"touch ID";
+        }
+        
+        if(appleWatchAllowed) {
+            //check if an apple watch auth occured after lid open
+            authTime = self.lastAppleWatchAuth;
+            authTypeFound = @"Apple Watch";
+        }
+        
         if(authTime && [authTime timeIntervalSinceDate:lidOpenTime] >= 0)
         {
-            os_log_debug(logHandle, "touch ID auth detected (%.1fs relative to lid open)",
-                         [authTime timeIntervalSinceDate:lidOpenTime]);
+            authMethodUsed = authTypeFound;
+            os_log_debug(logHandle, "%@ auth detected (%.1fs relative to lid open)",
+                         authTypeFound, [authTime timeIntervalSinceDate:lidOpenTime]);
             return YES;
         }
         
@@ -440,7 +468,7 @@ bail:
         elapsed += 0.25;
     }
     
-    os_log_debug(logHandle, "waitForTouchID: timed out after %.1fs", timeout);
+    os_log_debug(logHandle, "waitForSecureAuth: timed out after %.1fs", timeout);
     return NO;
 }
 

--- a/Installer/Source/ConfigureWindowController.h
+++ b/Installer/Source/ConfigureWindowController.h
@@ -49,6 +49,7 @@
 @property (strong) IBOutlet NSView *configureView;
 
 @property (weak) IBOutlet NSButton *passiveMode;
+@property (weak) IBOutlet NSButton *appleWatchMode;
 @property (weak) IBOutlet NSButton *touchIDMode;
 
 //preferences

--- a/Installer/Source/ConfigureWindowController.m
+++ b/Installer/Source/ConfigureWindowController.m
@@ -163,6 +163,7 @@ extern os_log_t logHandle;
     if( (ACTION_SHOW_CONFIGURATION+1) == action) {
         self.preferences = @{
             PREF_PASSIVE_MODE: @(self.passiveMode.state),
+            PREF_APPLE_WATCH_MODE: @(self.appleWatchMode.state),
             PREF_TOUCH_ID_MODE: @(self.touchIDMode.state)
         };
     }
@@ -293,6 +294,7 @@ extern os_log_t logHandle;
             NSDictionary* preferences = [NSDictionary dictionaryWithContentsOfFile:[INSTALL_DIRECTORY stringByAppendingPathComponent:PREFS_FILE]];
             if(preferences) {
                 self.passiveMode.state = [preferences[PREF_PASSIVE_MODE] integerValue];
+                self.appleWatchMode.state = [preferences[PREF_APPLE_WATCH_MODE] integerValue];
                 self.touchIDMode.state = [preferences[PREF_TOUCH_ID_MODE] integerValue];
             }
             
@@ -345,6 +347,7 @@ extern os_log_t logHandle;
                 execTask(OPEN, @[[@"/Applications" stringByAppendingPathComponent:APP_NAME],
                                 @"--args", INITIAL_LAUNCH,
                                  PREF_PASSIVE_MODE, [self.preferences[PREF_PASSIVE_MODE] description],
+                                 PREF_APPLE_WATCH_MODE, [self.preferences[PREF_APPLE_WATCH_MODE] description],
                                  PREF_TOUCH_ID_MODE, [self.preferences[PREF_TOUCH_ID_MODE] description]],
                                  NO, NO);
             }

--- a/shared/Consts.h
+++ b/shared/Consts.h
@@ -104,6 +104,7 @@
 
 #define PREF_NO_ICON_MODE @"noIconMode"
 #define PREF_PASSIVE_MODE @"passiveMode"
+#define PREF_APPLE_WATCH_MODE @"appleWatchMode"
 #define PREF_TOUCH_ID_MODE @"touchIDMode"
 
 #define PREF_CHAT_ID @"telegramChatID"


### PR DESCRIPTION
This is an attempt to support securely ignoring alerts when someone unlocks their Mac with an Apple Watch. As a heads up this is the first serious amount of Objective-C I've written so I mostly followed the code's existing patterns and duplicated->renamed to support the new option.

It's made up of three parts:
- Support validating and tracking`ES_AUTHENTICATION_TYPE_AUTO_UNLOCK` on `authentication->type` instead of only `ES_AUTHENTICATION_TYPE_TOUCHID`
- Refactoring the monitor to hardcode TouchID less, like in function names and strings
- A new preference and required plumbing for showing it, modifying it, etc

This is what the preferences UI looks like with the new setting addition inside the xib builder. I put the Apple Watch setting above TouchID for alphabetic reasons but would be happy to move it around within my ability:
<img width="660" height="289" alt="Screenshot 2026-05-04 at 10 59 25 PM" src="https://github.com/user-attachments/assets/cc65ee25-7dd7-47d7-8dd2-66bb13845bad" />

At this time I've only been able to validate that it builds locally. I haven't run anything yet because I'm not sure how to run an Endpoint Security daemon without the right entitlements. Do I need to temporarily disable SIP on my host OS? Maybe it be possible to get a testing build based off this branch's code once it otherwise looks ready? I have an Apple Watch so assuming a way to run the app is available I'll gladly test and validate.

Fixes #5 #34 